### PR TITLE
fix: remove `cross-fetch` from `fetcher-atama`

### DIFF
--- a/.changeset/dirty-experts-love.md
+++ b/.changeset/dirty-experts-love.md
@@ -1,0 +1,7 @@
+---
+"@atamaco/fetcher-atama": major
+---
+
+Remove `cross-fetch` from `fetcher-atama`. The `cross-fetch` package is causing issues in deno runtimes. Instead if someone is using `fetcher-atama` in Node 16 they have to add a fetch polyfill themselves
+
+i Please enter a summary for your changes.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: '16.x'
+          node-version-file: '.nvmrc'
       - name: Install
         run: npm install
       - name: "Lint last commit"

--- a/package-lock.json
+++ b/package-lock.json
@@ -4928,14 +4928,6 @@
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "dev": true
     },
-    "node_modules/cross-fetch": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.5.tgz",
-      "integrity": "sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==",
-      "dependencies": {
-        "node-fetch": "2.6.7"
-      }
-    },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -13879,7 +13871,7 @@
     },
     "packages/cx-core": {
       "name": "@atamaco/cx-core",
-      "version": "2.0.0",
+      "version": "3.0.0",
       "license": "MIT",
       "devDependencies": {
         "@atamaco/eslint-config-atama": "^1.3.0",
@@ -13902,10 +13894,10 @@
     },
     "packages/fetcher": {
       "name": "@atamaco/fetcher",
-      "version": "2.0.0",
+      "version": "3.0.0",
       "license": "MIT",
       "dependencies": {
-        "@atamaco/cx-core": "^2.0.0"
+        "@atamaco/cx-core": "^3.0.0"
       },
       "devDependencies": {
         "@atamaco/eslint-config-atama": "^1.3.0",
@@ -13915,11 +13907,10 @@
     },
     "packages/fetcher-atama": {
       "name": "@atamaco/fetcher-atama",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "license": "MIT",
       "dependencies": {
-        "@atamaco/fetcher": "^2.0.0",
-        "cross-fetch": "^3.1.5"
+        "@atamaco/fetcher": "^3.0.0"
       },
       "devDependencies": {
         "@atamaco/eslint-config-atama": "^1.3.0",
@@ -15069,10 +15060,10 @@
     },
     "packages/preview": {
       "name": "@atamaco/preview",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "license": "MIT",
       "dependencies": {
-        "@atamaco/preview-messaging": "^2.0.0"
+        "@atamaco/preview-messaging": "^3.0.0"
       },
       "devDependencies": {
         "@atamaco/eslint-config-atama": "^1.3.0",
@@ -15082,10 +15073,10 @@
     },
     "packages/preview-messaging": {
       "name": "@atamaco/preview-messaging",
-      "version": "2.0.0",
+      "version": "3.0.0",
       "license": "MIT",
       "dependencies": {
-        "@atamaco/cx-core": "^2.0.0"
+        "@atamaco/cx-core": "^3.0.0"
       },
       "devDependencies": {
         "@atamaco/eslint-config-atama": "^1.3.0",
@@ -15111,14 +15102,14 @@
     },
     "packages/preview-react": {
       "name": "@atamaco/preview-react",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "license": "MIT",
       "dependencies": {
-        "@atamaco/preview": "^2.0.0"
+        "@atamaco/preview": "^2.1.0"
       },
       "devDependencies": {
         "@atamaco/eslint-config-atama": "^1.3.0",
-        "@atamaco/renderer-react": "^2.0.0",
+        "@atamaco/renderer-react": "^3.0.0",
         "eslint": "^8.8.0",
         "react": "^17.0.2",
         "typescript": "4.5.4"
@@ -15155,10 +15146,10 @@
     },
     "packages/renderer-react": {
       "name": "@atamaco/renderer-react",
-      "version": "2.0.0",
+      "version": "3.0.0",
       "license": "MIT",
       "dependencies": {
-        "@atamaco/cx-core": "^2.0.0"
+        "@atamaco/cx-core": "^3.0.0"
       },
       "devDependencies": {
         "@atamaco/eslint-config-atama": "^1.3.0",
@@ -15186,10 +15177,10 @@
     },
     "packages/web/hydrogen": {
       "name": "@atamaco/hydrogen",
-      "version": "1.0.0",
+      "version": "1.0.2",
       "license": "MIT",
       "dependencies": {
-        "@atamaco/fetcher": "^2.0.0",
+        "@atamaco/fetcher": "^3.0.0",
         "@shopify/hydrogen": "^1.6.0"
       },
       "devDependencies": {
@@ -15311,10 +15302,10 @@
     },
     "packages/web/nextjs": {
       "name": "@atamaco/nextjs",
-      "version": "2.0.0",
+      "version": "3.0.0",
       "license": "MIT",
       "dependencies": {
-        "@atamaco/cx-core": "^2.0.0"
+        "@atamaco/cx-core": "^3.0.0"
       },
       "devDependencies": {
         "@atamaco/eslint-config-atama": "^1.3.0",
@@ -15491,7 +15482,7 @@
     "@atamaco/fetcher": {
       "version": "file:packages/fetcher",
       "requires": {
-        "@atamaco/cx-core": "^2.0.0",
+        "@atamaco/cx-core": "^3.0.0",
         "@atamaco/eslint-config-atama": "^1.3.0",
         "eslint": "^8.10.0",
         "typescript": "4.5.4"
@@ -15509,8 +15500,7 @@
       "version": "file:packages/fetcher-atama",
       "requires": {
         "@atamaco/eslint-config-atama": "^1.3.0",
-        "@atamaco/fetcher": "^2.0.0",
-        "cross-fetch": "^3.1.5",
+        "@atamaco/fetcher": "^3.0.0",
         "eslint": "^8.10.0",
         "jest": "^29.1.2",
         "msw": "^0.47.4",
@@ -16368,7 +16358,7 @@
       "version": "file:packages/web/hydrogen",
       "requires": {
         "@atamaco/eslint-config-atama": "^1.3.0",
-        "@atamaco/fetcher": "^2.0.0",
+        "@atamaco/fetcher": "^3.0.0",
         "@shopify/hydrogen": "^1.6.0",
         "eslint": "^8.8.0",
         "typescript": "4.5.4"
@@ -16448,7 +16438,7 @@
     "@atamaco/nextjs": {
       "version": "file:packages/web/nextjs",
       "requires": {
-        "@atamaco/cx-core": "^2.0.0",
+        "@atamaco/cx-core": "^3.0.0",
         "@atamaco/eslint-config-atama": "^1.3.0",
         "eslint": "^8.8.0",
         "next": "^12.0.10",
@@ -16515,7 +16505,7 @@
       "version": "file:packages/preview",
       "requires": {
         "@atamaco/eslint-config-atama": "^1.3.0",
-        "@atamaco/preview-messaging": "^2.0.0",
+        "@atamaco/preview-messaging": "^3.0.0",
         "eslint": "^8.8.0",
         "typescript": "4.5.4"
       },
@@ -16531,7 +16521,7 @@
     "@atamaco/preview-messaging": {
       "version": "file:packages/preview-messaging",
       "requires": {
-        "@atamaco/cx-core": "^2.0.0",
+        "@atamaco/cx-core": "^3.0.0",
         "@atamaco/eslint-config-atama": "^1.3.0",
         "@types/jest": "^27.4.0",
         "eslint": "^8.8.0",
@@ -16552,8 +16542,8 @@
       "version": "file:packages/preview-react",
       "requires": {
         "@atamaco/eslint-config-atama": "^1.3.0",
-        "@atamaco/preview": "^2.0.0",
-        "@atamaco/renderer-react": "^2.0.0",
+        "@atamaco/preview": "^2.1.0",
+        "@atamaco/renderer-react": "^3.0.0",
         "eslint": "^8.8.0",
         "react": "^17.0.2",
         "typescript": "4.5.4"
@@ -16570,7 +16560,7 @@
     "@atamaco/renderer-react": {
       "version": "file:packages/renderer-react",
       "requires": {
-        "@atamaco/cx-core": "^2.0.0",
+        "@atamaco/cx-core": "^3.0.0",
         "@atamaco/eslint-config-atama": "^1.3.0",
         "@types/react": "^17.0.39",
         "eslint": "^8.8.0",
@@ -20234,14 +20224,6 @@
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "dev": true
-    },
-    "cross-fetch": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.5.tgz",
-      "integrity": "sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==",
-      "requires": {
-        "node-fetch": "2.6.7"
-      }
     },
     "cross-spawn": {
       "version": "7.0.3",

--- a/packages/fetcher-atama/index.ts
+++ b/packages/fetcher-atama/index.ts
@@ -1,5 +1,4 @@
 import { Fetcher } from '@atamaco/fetcher';
-import fetch from 'cross-fetch';
 
 export interface AtamaFetcherConfig {
   apiKey: string;

--- a/packages/fetcher-atama/package.json
+++ b/packages/fetcher-atama/package.json
@@ -28,8 +28,7 @@
     "build": "tsc --project ./",
     "watch": "tsc --project ./ --watch",
     "lint": "eslint . --ext .ts,.tsx,.js",
-    "lint:fix": "npm run lint -- --fix",
-    "test": "jest --config .jest.config.json"
+    "lint:fix": "npm run lint -- --fix"
   },
   "devDependencies": {
     "@atamaco/eslint-config-atama": "^1.3.0",
@@ -40,7 +39,6 @@
     "typescript": "4.5.4"
   },
   "dependencies": {
-    "@atamaco/fetcher": "^3.0.0",
-    "cross-fetch": "^3.1.5"
+    "@atamaco/fetcher": "^3.0.0"
   }
 }


### PR DESCRIPTION
BREAKING CHANGE: The `cross-fetch` package was causing problems in Deno. Instead of trying to ensure polyfilling works correctly within the package we instead drop this. If someone is using `@atamaco/fetcher-atama` in Node 16/17 then they'll have to ensure to include a fetch polyfill themselves.