### PR TITLE
Throw error when React renderer doesn't receive data, layouts, or com…

### DIFF
--- a/.changeset/rotten-icons-press.md
+++ b/.changeset/rotten-icons-press.md
@@ -1,0 +1,5 @@
+---
+"@atamaco/renderer-react": patch
+---
+
+Throw error when React renderer doesn't receive data, layouts, or components

--- a/packages/renderer-react/atama-renderer.tsx
+++ b/packages/renderer-react/atama-renderer.tsx
@@ -29,8 +29,17 @@ export function AtamaRenderer<T>({
   components,
   data,
 }: AtamaRendererProps<T>) {
+  if (!data) {
+    throw new Error(`No data provided to AtamaRenderer.`);
+  }
+  if (!layouts) {
+    throw new Error(`No layout mapping provided to AtamaRenderer.`);
+  }
+  if (!components) {
+    throw new Error(`No component mapping provided to AtamaRenderer.`);
+  }
   if (!(data.template in layouts)) {
-    throw new Error(`Could not find ${data.template} in layouts`);
+    throw new Error(`Could not find '${data.template}' in layouts.`);
   }
 
   const Layout = layouts[data.template];


### PR DESCRIPTION
…ponents

I think when no data is returned from the Delivery API we need to catch it earlier.

Example of an error that I saw :
```
TypeError: Cannot read properties of undefined (reading 'template')
    at AtamaRenderer ([...]/node_modules/@atamaco/renderer-react/dist/atama-renderer.js:3:16)
```