### PR TITLE
feat: improved error handling for non-404 status codes

### DIFF
--- a/.changeset/rich-clouds-serve.md
+++ b/.changeset/rich-clouds-serve.md
@@ -1,0 +1,9 @@
+---
+"@atamaco/fetcher": major
+"@atamaco/fetcher-atama": major
+"@atamaco/nextjs": major
+---
+
+Added improved error handling for non-404 status codes returned from the Delivery API. Supporting one of `not_found`, `unauthorized` and a catch-all `internal_server_error`.
+
+This is relevant so when the Delivery API isn't functional (e.g. an outage) or an API key expired the page continues to function because ISR would continue serving the cached pages.

--- a/packages/fetcher/index.ts
+++ b/packages/fetcher/index.ts
@@ -1,4 +1,26 @@
+/* eslint-disable max-classes-per-file */
 import type { CXExperience } from '@atamaco/cx-core';
+
+export class AtamaFetcherError extends Error {
+  constructor(private readonly statusCode: number) {
+    let message = 'internal_server_error';
+
+    if (statusCode === 401) {
+      message = 'unauthorized';
+    }
+    if (statusCode === 404) {
+      message = 'not_found';
+    }
+
+    super(message);
+
+    Object.setPrototypeOf(this, AtamaFetcherError.prototype);
+  }
+
+  get status() {
+    return this.statusCode;
+  }
+}
 
 /**
  * Abstract class for a fetcher to implement fetching channel experiences
@@ -21,7 +43,7 @@ export abstract class Fetcher<C> {
    * Gets the data from a remote location and returns it
    * @param identifier The identifier to use for fetching data
    */
-  abstract getData<T>(identifier: string): Promise<CXExperience<T> | null>;
+  abstract getData<T>(identifier: string): Promise<CXExperience<T>>;
 
   /**
    * Get all paths that can be loaded as a page


### PR DESCRIPTION
Better handling for status codes returned from the Delivery API. Supporting one of `not_found`, `unauthorized` and a catch-all `internal_server_error`.

This is relevant so when the Delivery API isn't functional (e.g. an outage) or an API key expired the page continues to function because ISR would continue serving the cached pages.