### PR TITLE
chore: another version bump, this time minor instead of patch

### DIFF
--- a/.changeset/thin-teachers-sniff.md
+++ b/.changeset/thin-teachers-sniff.md
@@ -1,0 +1,6 @@
+---
+"@atamaco/fetcher": minor
+"@atamaco/fetcher-atama": patch
+---
+
+Creating a minor version change to accommodate the 'updateInternalDependencies' rule


### PR DESCRIPTION
I found this line in the changeset config, so i think this will changeset will actually do what i want

```
"updateInternalDependencies": "minor",
```