### PR TITLE
chore: bumping version of fetcher within hydrogen

### DIFF
--- a/.changeset/late-camels-matter.md
+++ b/.changeset/late-camels-matter.md
@@ -1,0 +1,5 @@
+---
+"@atamaco/hydrogen": minor
+---
+
+Bumping the version of the fetcher in an attempt to get the rendering working for the hydrogen demo site.

--- a/package-lock.json
+++ b/package-lock.json
@@ -13908,7 +13908,7 @@
     },
     "packages/cx-core": {
       "name": "@atamaco/cx-core",
-      "version": "3.0.0",
+      "version": "3.1.0",
       "license": "MIT",
       "devDependencies": {
         "@atamaco/eslint-config-atama": "^1.3.0",
@@ -13931,10 +13931,10 @@
     },
     "packages/fetcher": {
       "name": "@atamaco/fetcher",
-      "version": "4.0.0",
+      "version": "4.2.0",
       "license": "MIT",
       "dependencies": {
-        "@atamaco/cx-core": "^3.0.0"
+        "@atamaco/cx-core": "^3.1.0"
       },
       "devDependencies": {
         "@atamaco/eslint-config-atama": "^1.3.0",
@@ -13944,10 +13944,10 @@
     },
     "packages/fetcher-atama": {
       "name": "@atamaco/fetcher-atama",
-      "version": "4.0.0",
+      "version": "5.0.1",
       "license": "MIT",
       "dependencies": {
-        "@atamaco/fetcher": "^4.0.0",
+        "@atamaco/fetcher": "^4.2.0",
         "graphql-request": "^5.1.0"
       },
       "devDependencies": {
@@ -15218,7 +15218,7 @@
       "version": "1.0.3",
       "license": "MIT",
       "dependencies": {
-        "@atamaco/fetcher": "^4.0.0",
+        "@atamaco/fetcher": "^4.2.0",
         "@shopify/hydrogen": "^1.6.0"
       },
       "devDependencies": {
@@ -15520,7 +15520,7 @@
     "@atamaco/fetcher": {
       "version": "file:packages/fetcher",
       "requires": {
-        "@atamaco/cx-core": "^3.0.0",
+        "@atamaco/cx-core": "^3.1.0",
         "@atamaco/eslint-config-atama": "^1.3.0",
         "eslint": "^8.10.0",
         "typescript": "4.5.4"
@@ -15538,7 +15538,7 @@
       "version": "file:packages/fetcher-atama",
       "requires": {
         "@atamaco/eslint-config-atama": "^1.3.0",
-        "@atamaco/fetcher": "^4.0.0",
+        "@atamaco/fetcher": "^4.2.0",
         "eslint": "^8.10.0",
         "graphql-request": "^5.1.0",
         "jest": "^29.1.2",
@@ -16397,7 +16397,7 @@
       "version": "file:packages/web/hydrogen",
       "requires": {
         "@atamaco/eslint-config-atama": "^1.3.0",
-        "@atamaco/fetcher": "^4.0.0",
+        "@atamaco/fetcher": "^4.2.0",
         "@shopify/hydrogen": "^1.6.0",
         "eslint": "^8.8.0",
         "typescript": "4.5.4"

--- a/packages/web/hydrogen/package.json
+++ b/packages/web/hydrogen/package.json
@@ -36,7 +36,7 @@
     "typescript": "4.5.4"
   },
   "dependencies": {
-    "@atamaco/fetcher": "^4.0.0",
+    "@atamaco/fetcher": "^4.2.0",
     "@shopify/hydrogen": "^1.6.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
Bumping the version of the dependency on `@atamaco/fetcher` in the hydrogen renderer. hopefully this resolves the issues with the demo site rendering - I can't get it to do the same thing locally unfortunately.