### PR TITLE
fix: removing references to bundle manifest

### DIFF
--- a/.changeset/long-eagles-allow.md
+++ b/.changeset/long-eagles-allow.md
@@ -1,0 +1,6 @@
+---
+"@atamaco/cx-core": minor
+"@atamaco/fetcher-atama": minor
+---
+
+Removing Bundle Manifest since it will be retrieved on the backend by the delivery API and we no longer have to expose it directly to the client.

--- a/packages/cx-core/index.ts
+++ b/packages/cx-core/index.ts
@@ -97,28 +97,6 @@ export interface CXPlacement<T> {
 }
 
 /**
- * A bundle manifest containing information for actions.
- */
-export interface CXBundleManifest {
-  providers: {
-    type: string;
-    endpoint: string;
-  }[];
-  actions: {
-    actionId: string;
-    providerConfigs: {
-      providerConfigSecretArn: string;
-      type: string;
-      mappingDefinitions: {
-        key: string;
-        type: string;
-        instructions: string;
-      }[];
-    }[];
-  }[];
-}
-
-/**
  * An experience.
  */
 export interface CXExperience<T> {
@@ -138,8 +116,6 @@ export interface CXExperience<T> {
    * An array of placements within the embeddable blueprint.
    */
   placements: CXPlacement<T>[];
-
-  bundleManifest?: CXBundleManifest;
 }
 
 /**

--- a/packages/fetcher-atama/index.ts
+++ b/packages/fetcher-atama/index.ts
@@ -142,24 +142,6 @@ export class FetcherAtama extends Fetcher<AtamaFetcherConfig> {
                   componentTypeName
                 }
               }
-              bundleManifest {
-                providers {
-                  type
-                  endpoint
-                }
-                actions {
-                  actionId
-                  providerConfigs {
-                    providerConfigSecretArn
-                    type
-                    mappingDefinitions {
-                      key
-                      type
-                      instructions
-                    }
-                  }
-                }
-              }
             }
           }
         `,


### PR DESCRIPTION
Removing Bundle Manifest since it will be retrieved on the backend by the delivery API and we no longer have to expose it directly to the client