### PR TITLE
feat: added an integration for remix

### DIFF
--- a/.changeset/curly-tools-check.md
+++ b/.changeset/curly-tools-check.md
@@ -1,0 +1,12 @@
+---
+"@atamaco/remix": major
+"@atamaco/cx-core": minor
+"@atamaco/fetcher": minor
+"@atamaco/fetcher-atama": minor
+---
+
+Added an integration for [remix](https://remix.run/)
+
+- Updated `@atamaco/fetcher` and `@atamaco/fetcher-atama` to optionally accept a logger. It's a great way to hook into the internals of the CX SDK. If no logger is passed in nothing is logged to the console.
+- Updated `@atamaco/cx-core` with the `Logger` interface and added a helper method to find a component type in an experience.
+- Added `@atamaco/remix`. This is our latest framework integration. Supports rendering a path and has full support for actions ("read" actions as well as "write" actions). It also comes with optional cache support. Using some sort of cache greatly helps with performance to avoid re-fetching experiences on every request from the Delivery API. Instead e.g. an in-memory cache can be used.

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,5 +9,6 @@
     "packages/renderer-react",
     "packages/web/hydrogen",
     "packages/web/nextjs",
+    "packages/web/remix"
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -111,6 +111,10 @@
       "resolved": "packages/preview-react",
       "link": true
     },
+    "node_modules/@atamaco/remix": {
+      "resolved": "packages/web/remix",
+      "link": true
+    },
     "node_modules/@atamaco/renderer-react": {
       "resolved": "packages/renderer-react",
       "link": true
@@ -3071,6 +3075,53 @@
       "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.21.tgz",
       "integrity": "sha512-a5Sab1C4/icpTZVzZc5Ghpz88yQtGOyNqYXcZgOssB2uuAr+wF/MvN6bgtW32q7HHrvBki+BsZ0OuNv6EV3K9g=="
     },
+    "node_modules/@remix-run/router": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.3.2.tgz",
+      "integrity": "sha512-t54ONhl/h75X94SWsHGQ4G/ZrCEguKSRQr7DrjTciJXW0YU1QhlwYeycvK5JgkzlxmvrK7wq1NB/PLtHxoiDcA==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@remix-run/server-runtime": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/server-runtime/-/server-runtime-1.13.0.tgz",
+      "integrity": "sha512-gjIW3XCeIlOt3rrOZMD6HixQydRgs1SwYjP99ZAVruG2+gNq/tL2OusMFYTLvtWrybt215tPROyF/6iTLsaO3g==",
+      "dev": true,
+      "dependencies": {
+        "@remix-run/router": "1.3.2",
+        "@types/cookie": "^0.4.0",
+        "@types/react": "^18.0.15",
+        "@web3-storage/multipart-parser": "^1.0.0",
+        "cookie": "^0.4.1",
+        "set-cookie-parser": "^2.4.8",
+        "source-map": "^0.7.3"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@remix-run/server-runtime/node_modules/@types/react": {
+      "version": "18.0.28",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.0.28.tgz",
+      "integrity": "sha512-RD0ivG1kEztNBdoAK7lekI9M+azSnitIn85h4iOiaLjaTrMjzslhaqCGaI4IyCJ1RljWiLCEu4jyrLLgqxBTew==",
+      "dev": true,
+      "dependencies": {
+        "@types/prop-types": "*",
+        "@types/scheduler": "*",
+        "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@remix-run/server-runtime/node_modules/source-map": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
+      "integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/@rollup/pluginutils": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-4.2.1.tgz",
@@ -3629,6 +3680,12 @@
       "engines": {
         "node": ">=12.0.0"
       }
+    },
+    "node_modules/@web3-storage/multipart-parser": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@web3-storage/multipart-parser/-/multipart-parser-1.0.0.tgz",
+      "integrity": "sha512-BEO6al7BYqcnfX15W2cnGR+Q566ACXAT9UQykORCWW80lmkpWsnEob6zJS1ZVBKsSJC8+7vJkHwlp+lXG1UCdw==",
+      "dev": true
     },
     "node_modules/@xmldom/xmldom": {
       "version": "0.7.5",
@@ -13908,7 +13965,7 @@
     },
     "packages/cx-core": {
       "name": "@atamaco/cx-core",
-      "version": "3.1.0",
+      "version": "3.3.0",
       "license": "MIT",
       "devDependencies": {
         "@atamaco/eslint-config-atama": "^1.3.0",
@@ -13931,10 +13988,10 @@
     },
     "packages/fetcher": {
       "name": "@atamaco/fetcher",
-      "version": "4.2.0",
+      "version": "4.3.0",
       "license": "MIT",
       "dependencies": {
-        "@atamaco/cx-core": "^3.1.0"
+        "@atamaco/cx-core": "^3.3.0"
       },
       "devDependencies": {
         "@atamaco/eslint-config-atama": "^1.3.0",
@@ -13944,10 +14001,10 @@
     },
     "packages/fetcher-atama": {
       "name": "@atamaco/fetcher-atama",
-      "version": "5.0.2",
+      "version": "5.2.0",
       "license": "MIT",
       "dependencies": {
-        "@atamaco/fetcher": "^4.2.0",
+        "@atamaco/fetcher": "^4.3.0",
         "graphql-request": "^5.1.0"
       },
       "devDependencies": {
@@ -15185,10 +15242,10 @@
     },
     "packages/renderer-react": {
       "name": "@atamaco/renderer-react",
-      "version": "3.0.1",
+      "version": "3.1.0",
       "license": "MIT",
       "dependencies": {
-        "@atamaco/cx-core": "^3.0.0"
+        "@atamaco/cx-core": "^3.3.0"
       },
       "devDependencies": {
         "@atamaco/eslint-config-atama": "^1.3.0",
@@ -15341,10 +15398,10 @@
     },
     "packages/web/nextjs": {
       "name": "@atamaco/nextjs",
-      "version": "4.0.0",
+      "version": "4.1.0",
       "license": "MIT",
       "dependencies": {
-        "@atamaco/cx-core": "^3.0.0"
+        "@atamaco/cx-core": "^3.3.0"
       },
       "devDependencies": {
         "@atamaco/eslint-config-atama": "^1.3.0",
@@ -15448,6 +15505,37 @@
       "engines": {
         "node": ">=4.2.0"
       }
+    },
+    "packages/web/remix": {
+      "name": "@atamaco/remix",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@atamaco/cx-core": "^3.3.0",
+        "@atamaco/fetcher": "^4.2.0"
+      },
+      "devDependencies": {
+        "@atamaco/eslint-config-atama": "^1.3.0",
+        "@remix-run/server-runtime": "^1.13.0",
+        "eslint": "^8.8.0",
+        "typescript": "4.5.4"
+      },
+      "peerDependencies": {
+        "@remix-run/server-runtime": "*"
+      }
+    },
+    "packages/web/remix/node_modules/typescript": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.4.tgz",
+      "integrity": "sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
     }
   },
   "dependencies": {
@@ -15521,7 +15609,7 @@
     "@atamaco/fetcher": {
       "version": "file:packages/fetcher",
       "requires": {
-        "@atamaco/cx-core": "^3.1.0",
+        "@atamaco/cx-core": "^3.3.0",
         "@atamaco/eslint-config-atama": "^1.3.0",
         "eslint": "^8.10.0",
         "typescript": "4.5.4"
@@ -15539,7 +15627,7 @@
       "version": "file:packages/fetcher-atama",
       "requires": {
         "@atamaco/eslint-config-atama": "^1.3.0",
-        "@atamaco/fetcher": "^4.2.0",
+        "@atamaco/fetcher": "^4.3.0",
         "cross-fetch": "^3.1.5",
         "eslint": "^8.10.0",
         "graphql-request": "^5.1.0",
@@ -16479,7 +16567,7 @@
     "@atamaco/nextjs": {
       "version": "file:packages/web/nextjs",
       "requires": {
-        "@atamaco/cx-core": "^3.0.0",
+        "@atamaco/cx-core": "^3.3.0",
         "@atamaco/eslint-config-atama": "^1.3.0",
         "eslint": "^8.8.0",
         "next": "^12.0.10",
@@ -16598,10 +16686,29 @@
         }
       }
     },
+    "@atamaco/remix": {
+      "version": "file:packages/web/remix",
+      "requires": {
+        "@atamaco/cx-core": "*",
+        "@atamaco/eslint-config-atama": "^1.3.0",
+        "@atamaco/fetcher": "^4.2.0",
+        "@remix-run/server-runtime": "^1.13.0",
+        "eslint": "^8.8.0",
+        "typescript": "4.5.4"
+      },
+      "dependencies": {
+        "typescript": {
+          "version": "4.5.4",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.4.tgz",
+          "integrity": "sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg==",
+          "dev": true
+        }
+      }
+    },
     "@atamaco/renderer-react": {
       "version": "file:packages/renderer-react",
       "requires": {
-        "@atamaco/cx-core": "^3.0.0",
+        "@atamaco/cx-core": "^3.3.0",
         "@atamaco/eslint-config-atama": "^1.3.0",
         "@types/react": "^17.0.39",
         "eslint": "^8.8.0",
@@ -18857,6 +18964,46 @@
       "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.21.tgz",
       "integrity": "sha512-a5Sab1C4/icpTZVzZc5Ghpz88yQtGOyNqYXcZgOssB2uuAr+wF/MvN6bgtW32q7HHrvBki+BsZ0OuNv6EV3K9g=="
     },
+    "@remix-run/router": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.3.2.tgz",
+      "integrity": "sha512-t54ONhl/h75X94SWsHGQ4G/ZrCEguKSRQr7DrjTciJXW0YU1QhlwYeycvK5JgkzlxmvrK7wq1NB/PLtHxoiDcA==",
+      "dev": true
+    },
+    "@remix-run/server-runtime": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/server-runtime/-/server-runtime-1.13.0.tgz",
+      "integrity": "sha512-gjIW3XCeIlOt3rrOZMD6HixQydRgs1SwYjP99ZAVruG2+gNq/tL2OusMFYTLvtWrybt215tPROyF/6iTLsaO3g==",
+      "dev": true,
+      "requires": {
+        "@remix-run/router": "1.3.2",
+        "@types/cookie": "^0.4.0",
+        "@types/react": "^18.0.15",
+        "@web3-storage/multipart-parser": "^1.0.0",
+        "cookie": "^0.4.1",
+        "set-cookie-parser": "^2.4.8",
+        "source-map": "^0.7.3"
+      },
+      "dependencies": {
+        "@types/react": {
+          "version": "18.0.28",
+          "resolved": "https://registry.npmjs.org/@types/react/-/react-18.0.28.tgz",
+          "integrity": "sha512-RD0ivG1kEztNBdoAK7lekI9M+azSnitIn85h4iOiaLjaTrMjzslhaqCGaI4IyCJ1RljWiLCEu4jyrLLgqxBTew==",
+          "dev": true,
+          "requires": {
+            "@types/prop-types": "*",
+            "@types/scheduler": "*",
+            "csstype": "^3.0.2"
+          }
+        },
+        "source-map": {
+          "version": "0.7.4",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
+          "integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==",
+          "dev": true
+        }
+      }
+    },
     "@rollup/pluginutils": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-4.2.1.tgz",
@@ -19307,6 +19454,12 @@
         "react-refresh": "^0.13.0",
         "resolve": "^1.22.0"
       }
+    },
+    "@web3-storage/multipart-parser": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@web3-storage/multipart-parser/-/multipart-parser-1.0.0.tgz",
+      "integrity": "sha512-BEO6al7BYqcnfX15W2cnGR+Q566ACXAT9UQykORCWW80lmkpWsnEob6zJS1ZVBKsSJC8+7vJkHwlp+lXG1UCdw==",
+      "dev": true
     },
     "@xmldom/xmldom": {
       "version": "0.7.5",

--- a/packages/cx-core/index.ts
+++ b/packages/cx-core/index.ts
@@ -161,3 +161,30 @@ export interface ActionConfig {
    */
   apiRoutePath?: string;
 }
+
+/**
+ * The logging interface for the CX SDK.
+ */
+export interface Logger {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  error?: (message?: any, ...optionalParams: any[]) => void;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  warn?: (message?: any, ...optionalParams: any[]) => void;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  info?: (message?: any, ...optionalParams: any[]) => void;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  debug?: (message?: any, ...optionalParams: any[]) => void;
+}
+
+/**
+ * Find a component by the given component type
+ */
+export function findComponentByComponentType<T>(
+  experience: CXExperience<T>,
+  componentType: string,
+) {
+  return experience.placements
+    .flatMap((placement) => placement.components)
+    .filter((component) => !!component)
+    .filter((component) => component?.type === componentType)?.[0];
+}

--- a/packages/fetcher/index.ts
+++ b/packages/fetcher/index.ts
@@ -1,5 +1,5 @@
 /* eslint-disable max-classes-per-file */
-import type { CXExperience } from '@atamaco/cx-core';
+import type { CXExperience, Logger } from '@atamaco/cx-core';
 
 export class AtamaFetcherError extends Error {
   constructor(private readonly statusCode: number) {
@@ -35,11 +35,17 @@ export abstract class Fetcher<C> {
   config: C;
 
   /**
+   * The logger to use for logging
+   */
+  logger?: Logger;
+
+  /**
    * Initialize the fetcher
    * @param config The configuration for the Fetcher
    */
-  constructor(config: C) {
+  constructor(config: C, logger?: Logger) {
     this.config = config;
+    this.logger = logger;
   }
 
   /**

--- a/packages/web/remix/.eslintrc.js
+++ b/packages/web/remix/.eslintrc.js
@@ -1,0 +1,7 @@
+module.exports = {
+  extends: ['@atamaco/eslint-config-atama'],
+  parserOptions: {
+    project: './tsconfig.json',
+  },
+  ignorePatterns: [".*rc.js", "dist"],
+};

--- a/packages/web/remix/.prettierrc.js
+++ b/packages/web/remix/.prettierrc.js
@@ -1,0 +1,3 @@
+module.exports = {
+  ...require('@atamaco/eslint-config-atama/.prettierrc.js'),
+}

--- a/packages/web/remix/LICENSE.md
+++ b/packages/web/remix/LICENSE.md
@@ -1,0 +1,7 @@
+Copyright 2022 Atama Technologies, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/packages/web/remix/README.md
+++ b/packages/web/remix/README.md
@@ -1,0 +1,5 @@
+# Remix
+
+[Remix](https://remix.run/) is an open source React-based framework maintained by [Shopify](https://www.shopify.com/). Our CX Framework for Remix supports fetching data and running actions to drive your Custom Storefront with Atama.
+
+Learn more on the [Atama Documentation](https://docs.atama.co)

--- a/packages/web/remix/index.ts
+++ b/packages/web/remix/index.ts
@@ -1,0 +1,384 @@
+import type { CXExperience, Logger } from '@atamaco/cx-core';
+import type { Fetcher, AtamaFetcherError } from '@atamaco/fetcher';
+import type { AtamaFetcherConfig } from '@atamaco/fetcher-atama';
+import type { DataFunctionArgs } from '@remix-run/server-runtime';
+
+import { findComponentByComponentType } from '@atamaco/cx-core';
+import { json } from '@remix-run/server-runtime';
+
+interface ActionDefinition {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  input: (data: any, dataFnArgs: DataFunctionArgs) => Promise<object>;
+  output: (
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    data: any,
+    request: Request,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    inputResult: any,
+  ) => Promise<object | [object, ResponseInit]>;
+}
+
+interface DataCache {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  get: (key: string) => Promise<any>;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  set: (key: string, value: any) => void;
+  has: (key: string) => boolean;
+}
+
+type ActionsList = Record<string, ActionDefinition>;
+
+export interface GetComponentTypeReadActions {
+  (args: DataFunctionArgs): ActionsList;
+}
+
+export interface GetComponentTypeWriteActions {
+  (args: DataFunctionArgs): ActionsList;
+}
+
+function resolveUrlOrRequestToPath(urlOrRequest: Request | string) {
+  if (typeof urlOrRequest === 'string') {
+    return urlOrRequest;
+  }
+  const url = new URL(urlOrRequest.url);
+  return url.pathname;
+}
+
+export class AtamaClient<C = AtamaFetcherConfig> {
+  constructor(
+    private readonly fetcher: Fetcher<C>,
+    private readonly componentTypeActions?: {
+      read?: Record<string, Record<string, ActionDefinition>>;
+      write?: Record<string, Record<string, ActionDefinition>>;
+    },
+    private readonly logger?: Logger,
+    private readonly cache?: DataCache,
+  ) {}
+
+  // eslint-disable-next-line no-underscore-dangle
+  private async _loadPath<T>(path: string, args: DataFunctionArgs) {
+    let result;
+
+    this.logger?.info?.(`@atamaco/remix: Loading path ${path}`);
+    if (this.cache?.has(`#atama/path/${path}`)) {
+      this.logger?.debug?.(`@atamaco/remix: Cache hit for path ${path}`);
+      result = (await this.cache.get(`#atama/path/${path}`)) as CXExperience<T>;
+    } else {
+      try {
+        this.logger?.debug?.(
+          `@atamaco/remix: No cache hit. Loading experience data for path ${path} from Delivery API`,
+        );
+        result = await this.fetcher.getData<T>(path);
+
+        if (this.cache) {
+          this.logger?.debug?.(`@atamaco/remix: Caching data for path ${path}`);
+          this.cache.set(`#atama/path/${path}`, result);
+        }
+      } catch (error) {
+        this.logger?.error?.(
+          `@atamaco/remix: Could not load experience data for path ${path} from Delivery API`,
+          error,
+        );
+
+        if ((error as AtamaFetcherError).message === 'not_found') {
+          this.logger?.warn?.(
+            `@atamaco/remix: Loading experienced data for path ${path} failed with not_found from Delivery API`,
+          );
+          return {
+            status: 404,
+          } as const;
+        }
+
+        this.logger?.warn?.(
+          `@atamaco/remix: Loading experienced data for path ${path} failed with unknown error from Delivery API`,
+        );
+        return {
+          status: 500,
+        } as const;
+      }
+    }
+
+    const componentTypesActions = this.componentTypeActions?.read;
+
+    if (
+      !!componentTypesActions &&
+      Object.keys(componentTypesActions).length > 0
+    ) {
+      this.logger?.debug?.(`@atamaco/remix: Running actions for path ${path}`);
+
+      try {
+        const actionsToRun = result.placements.flatMap(
+          (placement) =>
+            placement.components
+              ?.filter((component) => component.type in componentTypesActions)
+              .flatMap((component) =>
+                component.actions
+                  .filter(
+                    (action) =>
+                      action.key in componentTypesActions[component.type],
+                  )
+                  .map((action) => ({
+                    action,
+                    component,
+                  })),
+              ) || [],
+        );
+
+        if (actionsToRun.length > 0) {
+          this.logger?.debug?.(
+            `@atamaco/remix: Running ${
+              actionsToRun.length
+            } actions for path ${path}: ${JSON.stringify(actionsToRun)}`,
+          );
+
+          await Promise.all(
+            actionsToRun.map(async (action) => {
+              this.logger?.debug?.(
+                `@atamaco/remix: Running action ${action.action.key} on ${action.component.type}`,
+              );
+              const inputResult = await componentTypesActions[
+                action.component.type
+              ][action.action.key].input(
+                action.component.contentProperties,
+                args,
+              );
+              const actionResult = await this.fetcher.action({
+                actionId: action.action.actionId,
+                input: inputResult,
+                slug: path,
+              });
+
+              this.logger?.debug?.(
+                `@atamaco/remix: Received data for action ${
+                  action.action.key
+                } on ${action.component.type}: ${JSON.stringify(actionResult)}`,
+              );
+
+              // eslint-disable-next-line no-param-reassign
+              action.component.contentProperties = await componentTypesActions[
+                action.component.type
+              ][action.action.key].output(
+                actionResult as object,
+                args.request,
+                inputResult,
+              );
+            }),
+          );
+        } else {
+          this.logger?.warn?.(
+            `@atamaco/remix: No components found to run actions for path ${path}`,
+          );
+        }
+      } catch (error) {
+        this.logger?.error?.(
+          '@atamaco/remix: Could not run one or more actions',
+          error,
+        );
+
+        return {
+          status: 500,
+        } as const;
+      }
+
+      return {
+        status: 200,
+        data: result,
+      } as const;
+    }
+
+    return {
+      status: 200,
+      data: result,
+    } as const;
+  }
+
+  /**
+   * Attempts to load a path from a list of paths. As soon as one path is found,
+   * it will return the data. If it cannot find a path it will throw a 404.
+   * Only throws a 500 if the fetcher throws a 500. This may happen at any of
+   * the paths in the list.
+   */
+  async loadPaths<T>(
+    args: DataFunctionArgs,
+    pathOrPaths: Array<Request | string>,
+  ) {
+    this.logger?.info?.(`@atamaco/remix: Loading paths`);
+
+    // eslint-disable-next-line no-restricted-syntax
+    for await (const urlOrRequest of pathOrPaths) {
+      try {
+        const path = resolveUrlOrRequestToPath(urlOrRequest);
+        this.logger?.debug?.(`@atamaco/remix: Attempting to load path ${path}`);
+
+        // If `loadPath` does not throw then we return the data
+        // eslint-disable-next-line no-underscore-dangle
+        const { status, data } = await this._loadPath<T>(path, args);
+
+        if (status === 200) {
+          this.logger?.debug?.(`@atamaco/remix: Loaded path ${path}`);
+          // If we get a 200 then we return the data
+          return data;
+        }
+        // Otherwise we continue the for loop
+        this.logger?.debug?.(
+          `@atamaco/remix: Could not find data for path ${path}. Continuing with next path.`,
+        );
+      } catch (error) {
+        // If a promise rejects with anything other than a 404 then we throw a
+        // 500 because that means there's an issue with the Delivery API.
+        // Reject early rather than bombarding the API with requests.
+        // eslint-disable-next-line @typescript-eslint/no-throw-literal
+        throw new Response('', { status: 500 });
+      }
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-throw-literal
+    throw new Response('', { status: 404 });
+  }
+
+  async loader<T>(args: DataFunctionArgs, pathOverride?: string) {
+    if (!pathOverride) {
+      return this.loadPaths<T>(args, [args.request]);
+    }
+
+    return this.loadPaths<T>(args, [pathOverride]);
+  }
+
+  async action<T>(args: DataFunctionArgs, pathOverride?: string) {
+    this.logger?.info?.(`@atamaco/remix: Running action`);
+    if (!this.componentTypeActions?.write) {
+      throw new Error('No write actions defined');
+    }
+
+    let path: string;
+    if (pathOverride) {
+      path = pathOverride;
+    } else {
+      const url = new URL(args.request.url);
+      path = url.pathname;
+    }
+
+    const body = await args.request.formData();
+    const {
+      actionKey: omittedActionKey,
+      componentType: omittedComponentType,
+      ...formData
+    } = Object.fromEntries(body.entries());
+    const actionKey = body.get('actionKey') as string;
+    const componentType = body.get('componentType') as string;
+
+    const componentTypeActionDefinitions =
+      this.componentTypeActions?.write[componentType];
+    const actionDefinition = componentTypeActionDefinitions[actionKey];
+
+    if (!actionDefinition) {
+      this.logger?.error?.(
+        `@atamaco/remix: Unknown action "${actionKey}" for component type "${componentType}"`,
+      );
+
+      return new Response(undefined, {
+        status: 400,
+      });
+    }
+
+    this.logger?.debug?.(
+      `@atamaco/remix: Loading path ${path} to get action information.`,
+    );
+    // eslint-disable-next-line no-underscore-dangle
+    const { data: experience, status } = await this._loadPath(path, args);
+
+    if (status === 404 || status === 500) {
+      this.logger?.error?.(
+        `@atamaco/remix: Unable to load path "${path}". Status: ${status}`,
+      );
+
+      return new Response(undefined, {
+        status,
+      });
+    }
+
+    const actualComponentType = findComponentByComponentType(
+      experience!,
+      componentType,
+    );
+
+    if (!actualComponentType) {
+      this.logger?.error?.(
+        `@atamaco/remix: Unable to find component type "${componentType}" in experience "${path}"`,
+      );
+
+      return new Response(undefined, {
+        status: 500,
+      });
+    }
+
+    const actionId = actualComponentType.actions.find(
+      (action) => action.key === actionKey,
+    )?.actionId;
+
+    if (!actionId) {
+      this.logger?.error?.(
+        `@atamaco/remix: Unable to find action "${actionKey}" in component type "${componentType}"`,
+      );
+
+      return new Response(undefined, {
+        status: 500,
+      });
+    }
+
+    let result;
+    let inputResult;
+    try {
+      this.logger?.debug?.(
+        `@atamaco/remix: Running action "${actionKey}" on "${componentType}"`,
+      );
+
+      inputResult = (await actionDefinition.input(
+        formData,
+        args,
+      )) as unknown as T;
+
+      this.logger?.debug?.(
+        `@atamaco/remix: Running action "${actionKey}" with the following input: ${JSON.stringify(
+          inputResult,
+        )}`,
+      );
+
+      result = await this.fetcher.action<T, unknown>({
+        actionId,
+        input: inputResult,
+        slug: path,
+      });
+    } catch (error) {
+      this.logger?.error?.(
+        `@atamaco/remix: Error running action "${actionKey}"`,
+        error,
+      );
+
+      return json('', {
+        status: 500,
+      });
+    }
+
+    this.logger?.debug?.(
+      `@atamaco/remix: Passing action result to output transform for action "${actionKey}"`,
+    );
+    const response = await actionDefinition.output(
+      result,
+      args.request,
+      inputResult,
+    );
+
+    this.logger?.debug?.(
+      `@atamaco/remix: Got the following output from action "${actionKey}": ${JSON.stringify(
+        response,
+      )}`,
+    );
+
+    if (Array.isArray(response)) {
+      return json(response[0], response[1]);
+    }
+
+    return json(response);
+  }
+}

--- a/packages/web/remix/package.json
+++ b/packages/web/remix/package.json
@@ -1,0 +1,46 @@
+{
+  "name": "@atamaco/remix",
+  "version": "0.1.0",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "license": "MIT",
+  "scripts": {
+    "build": "tsc --project ./",
+    "watch": "tsc --project ./ --watch",
+    "lint": "eslint . --ext .ts,.tsx,.js",
+    "lint:fix": "npm run lint -- --fix"
+  },
+  "files": [
+    "/dist",
+    "LICENSE.md"
+  ],
+  "bugs": {
+    "url": "https://github.com/AtamaCo/cx/issues"
+  },
+  "author": "The Atama Team (https://atama.co)",
+  "keywords": [
+    "atamaco",
+    "composable",
+    "remix",
+    "javascript",
+    "typescript"
+  ],
+  "homepage": "https://github.com/AtamaCo/cx#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/AtamaCo/cx.git"
+  },
+  "devDependencies": {
+    "@atamaco/eslint-config-atama": "^1.3.0",
+    "@remix-run/server-runtime": "^1.13.0",
+    "eslint": "^8.8.0",
+    "typescript": "4.5.4"
+  },
+  "dependencies": {
+    "@atamaco/cx-core": "^3.3.0",
+    "@atamaco/fetcher": "^4.2.0"
+  },
+  "peerDependencies": {
+    "@remix-run/server-runtime": "*"
+  }
+}

--- a/packages/web/remix/tsconfig.json
+++ b/packages/web/remix/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ES2019",
+    "module": "ESNext",
+    "moduleResolution": "node",
+    "lib": [
+      "DOM",
+      "ES2019",
+      "DOM.Iterable"
+    ],
+    "outDir": "./dist",
+    "declaration": true,
+    "skipLibCheck": true
+  },
+  "watchOptions": {
+    "watchFile": "useFsEvents",
+    "watchDirectory": "useFsEvents",
+    "fallbackPolling": "dynamicPriority",
+    "synchronousWatchDirectory": true,
+    "excludeDirectories": ["**/node_modules", "dist"]
+  }
+}


### PR DESCRIPTION
- Updated `@atamaco/fetcher` and `@atamaco/fetcher-atama` to optionally accept a logger. It's a great way to hook into the internals of the CX SDK. If no logger is passed in nothing is logged to the console.
- Updated `@atamaco/cx-core` with the `Logger` interface and added a helper method to find a component type in an experience.
- Added `@atamaco/remix`. This is our latest framework integration. Supports rendering a path and has full support for actions ("read" actions as well as "write" actions). It also comes with optional cache support. Using some sort of cache greatly helps with performance to avoid re-fetching experiences on every request from the Delivery API. Instead e.g. an in-memory cache can be used.